### PR TITLE
Updates for parmest redesign

### DIFF
--- a/pyomo/contrib/parmest/examples/reactor_design/timeseries_data_example.py
+++ b/pyomo/contrib/parmest/examples/reactor_design/timeseries_data_example.py
@@ -23,15 +23,16 @@ class TimeSeriesReactorDesignExperiment(ReactorDesignExperiment):
     def __init__(self, data, experiment_number):
         self.data = data
         self.experiment_number = experiment_number
-        self.data_i = data[experiment_number]
+        data_i = data.loc[data['experiment'] == experiment_number,:]
+        self.data_i = data_i.reset_index()
         self.model = None
 
     def finalize_model(self):
         m = self.model
 
         # Experiment inputs values
-        m.sv = self.data_i['sv']
-        m.caf = self.data_i['caf']
+        m.sv = self.data_i['sv'].mean()
+        m.caf = self.data_i['caf'].mean()
 
         # Experiment output values
         m.ca = self.data_i['ca'][0]
@@ -42,59 +43,18 @@ class TimeSeriesReactorDesignExperiment(ReactorDesignExperiment):
         return m
 
 
-def group_data(data, groupby_column_name, use_mean=None):
-    """
-    Group data by scenario
-
-    Parameters
-    ----------
-    data: DataFrame
-        Data
-    groupby_column_name: strings
-        Name of data column which contains scenario numbers
-    use_mean: list of column names or None, optional
-        Name of data columns which should be reduced to a single value per
-        scenario by taking the mean
-
-    Returns
-    ----------
-    grouped_data: list of dictionaries
-        Grouped data
-    """
-    if use_mean is None:
-        use_mean_list = []
-    else:
-        use_mean_list = use_mean
-
-    grouped_data = []
-    for exp_num, group in data.groupby(data[groupby_column_name]):
-        d = {}
-        for col in group.columns:
-            if col in use_mean_list:
-                d[col] = group[col].mean()
-            else:
-                d[col] = list(group[col])
-        grouped_data.append(d)
-
-    return grouped_data
-
-
 def main():
-    # Parameter estimation using timeseries data
+    # Parameter estimation using timeseries data, grouped by experiment number
 
     # Data, includes multiple sensors for ca and cc
     file_dirname = dirname(abspath(str(__file__)))
     file_name = abspath(join(file_dirname, 'reactor_data_timeseries.csv'))
     data = pd.read_csv(file_name)
 
-    # Group time series data into experiments, return the mean value for sv and caf
-    # Returns a list of dictionaries
-    data_ts = group_data(data, 'experiment', ['sv', 'caf'])
-
     # Create an experiment list
     exp_list = []
-    for i in range(len(data_ts)):
-        exp_list.append(TimeSeriesReactorDesignExperiment(data_ts, i))
+    for i in data['experiment'].unique():
+        exp_list.append(TimeSeriesReactorDesignExperiment(data, i))
 
     def SSE_timeseries(model):
 

--- a/pyomo/contrib/parmest/examples/rooney_biegler/bootstrap_example.py
+++ b/pyomo/contrib/parmest/examples/rooney_biegler/bootstrap_example.py
@@ -35,7 +35,7 @@ def main():
     # Create an experiment list
     exp_list = []
     for i in range(data.shape[0]):
-        exp_list.append(RooneyBieglerExperiment(data.loc[i, :].to_frame().transpose()))
+        exp_list.append(RooneyBieglerExperiment(data.loc[i, :]))
 
     # View one model
     # exp0_model = exp_list[0].get_labeled_model()

--- a/pyomo/contrib/parmest/examples/rooney_biegler/likelihood_ratio_example.py
+++ b/pyomo/contrib/parmest/examples/rooney_biegler/likelihood_ratio_example.py
@@ -36,7 +36,7 @@ def main():
     # Create an experiment list
     exp_list = []
     for i in range(data.shape[0]):
-        exp_list.append(RooneyBieglerExperiment(data.loc[i, :].to_frame().transpose()))
+        exp_list.append(RooneyBieglerExperiment(data.loc[i, :]))
 
     # View one model
     # exp0_model = exp_list[0].get_labeled_model()

--- a/pyomo/contrib/parmest/examples/rooney_biegler/parameter_estimation_example.py
+++ b/pyomo/contrib/parmest/examples/rooney_biegler/parameter_estimation_example.py
@@ -35,7 +35,7 @@ def main():
     # Create an experiment list
     exp_list = []
     for i in range(data.shape[0]):
-        exp_list.append(RooneyBieglerExperiment(data.loc[i, :].to_frame().transpose()))
+        exp_list.append(RooneyBieglerExperiment(data.loc[i, :]))
 
     # View one model
     # exp0_model = exp_list[0].get_labeled_model()

--- a/pyomo/contrib/parmest/examples/rooney_biegler/rooney_biegler.py
+++ b/pyomo/contrib/parmest/examples/rooney_biegler/rooney_biegler.py
@@ -52,15 +52,17 @@ class RooneyBieglerExperiment(Experiment):
         self.model = None
 
     def create_model(self):
-        self.model = rooney_biegler_model(self.data)
+        # rooney_biegler_model expects a dataframe
+        data_df = self.data.to_frame().transpose()
+        self.model = rooney_biegler_model(data_df)
 
     def label_model(self):
 
         m = self.model
 
         m.experiment_outputs = pyo.Suffix(direction=pyo.Suffix.LOCAL)
-        m.experiment_outputs.update([(m.hour, self.data.iloc[0]['hour'])])
-        m.experiment_outputs.update([(m.y, self.data.iloc[0]['y'])])
+        m.experiment_outputs.update([(m.hour, self.data['hour'])])
+        m.experiment_outputs.update([(m.y, self.data['y'])])
 
         m.unknown_parameters = pyo.Suffix(direction=pyo.Suffix.LOCAL)
         m.unknown_parameters.update(
@@ -72,8 +74,8 @@ class RooneyBieglerExperiment(Experiment):
         m = self.model
 
         # Experiment output values
-        m.hour = self.data.iloc[0]['hour']
-        m.y = self.data.iloc[0]['y']
+        m.hour = self.data['hour']
+        m.y = self.data['y']
 
     def get_labeled_model(self):
         self.create_model()

--- a/pyomo/contrib/parmest/examples/rooney_biegler/rooney_biegler_with_constraint.py
+++ b/pyomo/contrib/parmest/examples/rooney_biegler/rooney_biegler_with_constraint.py
@@ -56,15 +56,17 @@ class RooneyBieglerExperiment(Experiment):
         self.model = None
 
     def create_model(self):
-        self.model = rooney_biegler_model_with_constraint(self.data)
+        # rooney_biegler_model_with_constraint expects a dataframe
+        data_df = self.data.to_frame().transpose()
+        self.model = rooney_biegler_model_with_constraint(data_df)
 
     def label_model(self):
 
         m = self.model
 
         m.experiment_outputs = pyo.Suffix(direction=pyo.Suffix.LOCAL)
-        m.experiment_outputs.update([(m.hour, self.data.iloc[0]['hour'])])
-        m.experiment_outputs.update([(m.y, self.data.iloc[0]['y'])])
+        m.experiment_outputs.update([(m.hour, self.data['hour'])])
+        m.experiment_outputs.update([(m.y, self.data['y'])])
 
         m.unknown_parameters = pyo.Suffix(direction=pyo.Suffix.LOCAL)
         m.unknown_parameters.update(
@@ -76,8 +78,8 @@ class RooneyBieglerExperiment(Experiment):
         m = self.model
 
         # Experiment output values
-        m.hour = self.data.iloc[0]['hour']
-        m.y = self.data.iloc[0]['y']
+        m.hour = self.data['hour']
+        m.y = self.data['y']
 
     def get_labeled_model(self):
         self.create_model()

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -16,7 +16,6 @@
 # TODO: move use_mpisppy to a Pyomo configuration option
 
 # Redesign TODOS
-# TODO: remove group_data,this is only used in 1 example and should be handled by the user in Experiment
 # TODO: _treemaker is not used in parmest, the code could be moved to scenario tree if needed
 # TODO: Create additional built in objective expressions in an Enum class which includes SSE (see SSE function below)
 # TODO: Clean up the use of theta_names through out the code.  The Experiment returns the CUID of each theta and this can be used directly (instead of the name)
@@ -271,44 +270,6 @@ def _experiment_instance_creation_callback(
 #             m.ScenarioLeafNode[node.replace('LeafNode_', '')] = node
 
 #     return m
-
-
-# def group_data(data, groupby_column_name, use_mean=None):
-#     """
-#     Group data by scenario
-
-#     Parameters
-#     ----------
-#     data: DataFrame
-#         Data
-#     groupby_column_name: strings
-#         Name of data column which contains scenario numbers
-#     use_mean: list of column names or None, optional
-#         Name of data columns which should be reduced to a single value per
-#         scenario by taking the mean
-
-#     Returns
-#     ----------
-#     grouped_data: list of dictionaries
-#         Grouped data
-#     """
-#     if use_mean is None:
-#         use_mean_list = []
-#     else:
-#         use_mean_list = use_mean
-
-#     grouped_data = []
-#     for exp_num, group in data.groupby(data[groupby_column_name]):
-#         d = {}
-#         for col in group.columns:
-#             if col in use_mean_list:
-#                 d[col] = group[col].mean()
-#             else:
-#                 d[col] = list(group[col])
-#         grouped_data.append(d)
-
-#     return grouped_data
-
 
 def SSE(model):
     expr = sum((y - yhat) ** 2 for y, yhat in model.experiment_outputs.items())

--- a/pyomo/contrib/parmest/tests/test_parmest.py
+++ b/pyomo/contrib/parmest/tests/test_parmest.py
@@ -77,7 +77,7 @@ class TestRooneyBiegler(unittest.TestCase):
         exp_list = []
         for i in range(data.shape[0]):
             exp_list.append(
-                RooneyBieglerExperiment(data.loc[i, :].to_frame().transpose())
+                RooneyBieglerExperiment(data.loc[i, :])
             )
 
         # Create an instance of the parmest estimator
@@ -386,13 +386,14 @@ class TestModelVariants(unittest.TestCase):
         class RooneyBieglerExperimentParams(RooneyBieglerExperiment):
 
             def create_model(self):
-                self.model = rooney_biegler_params(self.data)
+                data_df = self.data.to_frame().transpose()
+                self.model = rooney_biegler_params(data_df)
 
         rooney_biegler_params_exp_list = []
         for i in range(self.data.shape[0]):
             rooney_biegler_params_exp_list.append(
                 RooneyBieglerExperimentParams(
-                    self.data.loc[i, :].to_frame().transpose()
+                    self.data.loc[i, :]
                 )
             )
 
@@ -422,15 +423,16 @@ class TestModelVariants(unittest.TestCase):
         class RooneyBieglerExperimentIndexedParams(RooneyBieglerExperiment):
 
             def create_model(self):
-                self.model = rooney_biegler_indexed_params(self.data)
+                data_df = self.data.to_frame().transpose()
+                self.model = rooney_biegler_indexed_params(data_df)
 
             def label_model(self):
 
                 m = self.model
 
                 m.experiment_outputs = pyo.Suffix(direction=pyo.Suffix.LOCAL)
-                m.experiment_outputs.update([(m.hour, self.data.iloc[0]['hour'])])
-                m.experiment_outputs.update([(m.y, self.data.iloc[0]['y'])])
+                m.experiment_outputs.update([(m.hour, self.data['hour'])])
+                m.experiment_outputs.update([(m.y, self.data['y'])])
 
                 m.unknown_parameters = pyo.Suffix(direction=pyo.Suffix.LOCAL)
                 m.unknown_parameters.update((k, pyo.ComponentUID(k)) for k in [m.theta])
@@ -439,7 +441,7 @@ class TestModelVariants(unittest.TestCase):
         for i in range(self.data.shape[0]):
             rooney_biegler_indexed_params_exp_list.append(
                 RooneyBieglerExperimentIndexedParams(
-                    self.data.loc[i, :].to_frame().transpose()
+                    self.data.loc[i, :]
                 )
             )
 
@@ -465,12 +467,13 @@ class TestModelVariants(unittest.TestCase):
         class RooneyBieglerExperimentVars(RooneyBieglerExperiment):
 
             def create_model(self):
-                self.model = rooney_biegler_vars(self.data)
+                data_df = self.data.to_frame().transpose()
+                self.model = rooney_biegler_vars(data_df)
 
         rooney_biegler_vars_exp_list = []
         for i in range(self.data.shape[0]):
             rooney_biegler_vars_exp_list.append(
-                RooneyBieglerExperimentVars(self.data.loc[i, :].to_frame().transpose())
+                RooneyBieglerExperimentVars(self.data.loc[i, :])
             )
 
         def rooney_biegler_indexed_vars(data):
@@ -501,15 +504,16 @@ class TestModelVariants(unittest.TestCase):
         class RooneyBieglerExperimentIndexedVars(RooneyBieglerExperiment):
 
             def create_model(self):
-                self.model = rooney_biegler_indexed_vars(self.data)
+                data_df = self.data.to_frame().transpose()
+                self.model = rooney_biegler_indexed_vars(data_df)
 
             def label_model(self):
 
                 m = self.model
 
                 m.experiment_outputs = pyo.Suffix(direction=pyo.Suffix.LOCAL)
-                m.experiment_outputs.update([(m.hour, self.data.iloc[0]['hour'])])
-                m.experiment_outputs.update([(m.y, self.data.iloc[0]['y'])])
+                m.experiment_outputs.update([(m.hour, self.data['hour'])])
+                m.experiment_outputs.update([(m.y, self.data['y'])])
 
                 m.unknown_parameters = pyo.Suffix(direction=pyo.Suffix.LOCAL)
                 m.unknown_parameters.update((k, pyo.ComponentUID(k)) for k in [m.theta])
@@ -518,7 +522,7 @@ class TestModelVariants(unittest.TestCase):
         for i in range(self.data.shape[0]):
             rooney_biegler_indexed_vars_exp_list.append(
                 RooneyBieglerExperimentIndexedVars(
-                    self.data.loc[i, :].to_frame().transpose()
+                    self.data.loc[i, :]
                 )
             )
 
@@ -985,7 +989,7 @@ class TestSquareInitialization_RooneyBiegler(unittest.TestCase):
         exp_list = []
         for i in range(data.shape[0]):
             exp_list.append(
-                RooneyBieglerExperiment(data.loc[i, :].to_frame().transpose())
+                RooneyBieglerExperiment(data.loc[i, :])
             )
 
         solver_options = {"tol": 1e-8}


### PR DESCRIPTION
## Summary/Motivation:
WIP code review

## Changes proposed in this PR:
- Removed the use of group_data function in timeseries example, I think it's more clear to group the data and aggregate directly
- Cleaned up the use of .to_frame().transpose() to convert data from series to dataframe.  This is now in create_model for Rooney Biegler examples.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
